### PR TITLE
Modernize plugin build and APIs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+---
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,29 @@
+# Additional setup is documented at https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+---
+name: cd
+on:
+  workflow_dispatch:
+    inputs:
+      validate_only:
+        required: false
+        type: boolean
+        description: |
+          Run validation with release drafter only
+          Skip the release job
+        default: false
+  check_run:
+    types:
+      - completed
+
+permissions:
+  checks: read
+  contents: write
+
+jobs:
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    with:
+      validate_only: ${{ inputs.validate_only == true }}
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,9 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.13</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 buildPlugin(
     configurations: [
+        [platform: 'linux', jdk: 25],
         [platform: 'linux', jdk: 21],
         [platform: 'windows', jdk: 17],
     ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,7 @@
-buildPlugin()
+buildPlugin(
+    configurations: [
+        [platform: 'linux', jdk: 21],
+        [platform: 'windows', jdk: 17],
+    ],
+    useContainerAgent: true,
+)

--- a/pom.xml
+++ b/pom.xml
@@ -28,45 +28,68 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.6</version>
+    <version>6.2208.vb_6798604237e</version>
     <relativePath />
   </parent>
 
   <artifactId>build-token-trigger</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>${revision}.${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Build Token Trigger Plugin</name>
   <description>
     This plugin provides a pipeline step to trigger a build using the Build Authorization Token Root plugin.
   </description>
+  <url>https://github.com/${gitHubRepo}</url>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
 
   <scm>
-    <connection>scm:git:ssh://git@github.com/jenkinsci/build-token-trigger-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/build-token-trigger-plugin.git</developerConnection>
-    <tag>HEAD</tag>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <properties>
-    <jenkins.version>2.89.1</jenkins.version>
-    <java.level>8</java.level>
+    <revision>1.1</revision>
+    <changelist>999999-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/build-token-trigger-plugin</gitHubRepo>
+    <jenkins.baseline>2.541</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.bom.version>6210.v69ea_fd8a_f010</jenkins.bom.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>${jenkins.bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.16</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.14</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>build-token-root</artifactId>
-      <version>1.4</version>
+      <version>151.va_e52fe3215fc</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>build-token-trigger</artifactId>
-  <version>${revision}.${changelist}</version>
+  <version>${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Build Token Trigger Plugin</name>
@@ -57,12 +57,10 @@
   </scm>
 
   <properties>
-    <revision>1.1</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/build-token-trigger-plugin</gitHubRepo>
     <jenkins.baseline>2.541</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <jenkins.bom.version>6210.v69ea_fd8a_f010</jenkins.bom.version>
   </properties>
 
   <dependencyManagement>
@@ -70,7 +68,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>${jenkins.bom.version}</version>
+        <version>6210.v69ea_fd8a_f010</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -90,6 +88,16 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>build-token-root</artifactId>
       <version>151.va_e52fe3215fc</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentials.java
@@ -29,7 +29,7 @@ import com.cloudbees.plugins.credentials.common.PasswordCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.BuildAuthorizationToken;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A {@link BuildAuthorizationToken} for another Jenkins.

--- a/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentials.java
@@ -29,7 +29,6 @@ import com.cloudbees.plugins.credentials.common.PasswordCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.BuildAuthorizationToken;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * A {@link BuildAuthorizationToken} for another Jenkins.
@@ -56,7 +55,7 @@ public interface TriggerCredentials extends StandardCredentials, PasswordCredent
         @Override
         public String getName(@NonNull TriggerCredentials credentials) {
             String description = credentials.getDescription();
-            if (StringUtils.isBlank(description)) {
+            if (description == null || description.isBlank()) {
                 return credentials.getId() + " [" + credentials.getJenkinsUrl() + "]";
             } else {
                 return credentials.getId() + " [" + credentials.getJenkinsUrl() + ("] (" + description + ")");

--- a/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentialsImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentialsImpl.java
@@ -38,7 +38,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentialsImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentialsImpl.java
@@ -38,7 +38,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
-import org.apache.commons.lang3.StringUtils;
+import java.util.Objects;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -66,7 +66,7 @@ public class TriggerCredentialsImpl extends BaseStandardCredentials implements T
      */
     @NonNull
     public static String normalizeUrl(@CheckForNull String url) {
-        url = StringUtils.defaultString(url);
+        url = url == null ? "" : url;
         try {
             URI uri = new URI(url).normalize();
             String scheme = uri.getScheme();
@@ -138,7 +138,7 @@ public class TriggerCredentialsImpl extends BaseStandardCredentials implements T
             try {
                 String url = normalizeUrl(value);
                 new URL(url);
-                if (StringUtils.equals(value, url)) {
+                if (Objects.equals(value, url)) {
                     return FormValidation.ok();
                 }
                 return FormValidation.warningWithMarkup(

--- a/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
@@ -30,7 +30,6 @@ import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.ProxyConfiguration;
@@ -61,13 +60,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -216,7 +215,7 @@ public class TriggerStep extends Step implements Serializable {
             }
             String delayStr = json.getString("delay");
             Integer delay;
-            if (StringUtils.isBlank(delayStr)) {
+            if (isBlank(delayStr)) {
                 delay = null;
             } else {
                 try {
@@ -233,7 +232,7 @@ public class TriggerStep extends Step implements Serializable {
         }
 
         public FormValidation doCheckDelay(@QueryParameter String value) {
-            if (StringUtils.isBlank(value)) {
+            if (isBlank(value)) {
                 return FormValidation.ok();
             }
             try {
@@ -248,7 +247,7 @@ public class TriggerStep extends Step implements Serializable {
         }
 
         public FormValidation doCheckJob(@QueryParameter String value) {
-            if (StringUtils.isBlank(value)) {
+            if (isBlank(value)) {
                 return FormValidation.error("Must specify job to trigger");
             }
             return FormValidation.ok();
@@ -261,9 +260,9 @@ public class TriggerStep extends Step implements Serializable {
             if (owner == null || !owner.hasPermission(Item.CONFIGURE)) {
                 return FormValidation.ok();
             }
-            if (StringUtils.isBlank(value)) {
+            if (isBlank(value)) {
                 String url = JenkinsLocationConfiguration.get().getUrl();
-                if (StringUtils.isBlank(url)) {
+                if (isBlank(url)) {
                     return FormValidation
                             .error("No Jenkins URL specified and this Jenkins has not been configured with a root URL"
                                     + " so cannot use that as a default");
@@ -282,7 +281,7 @@ public class TriggerStep extends Step implements Serializable {
             try {
                 connection.getResponseCode();
                 String version = connection.getHeaderField("X-Jenkins");
-                if (StringUtils.isBlank(version)) {
+                if (isBlank(version)) {
                     return FormValidation.warningWithMarkup(
                             "Does not look like a Jenkins URL, expecting <code>X-Jenkins</code> header");
                 }
@@ -317,14 +316,17 @@ public class TriggerStep extends Step implements Serializable {
         static CredentialsMatcher matchingJenkinsUrl(String jenkinsUrl) {
             String normalizedUrl = TriggerCredentialsImpl.normalizeUrl(jenkinsUrl);
             return credentials -> credentials instanceof TriggerCredentials
-                    && StringUtils.equals(((TriggerCredentials) credentials).getJenkinsUrl(), normalizedUrl);
+                    && Objects.equals(((TriggerCredentials) credentials).getJenkinsUrl(), normalizedUrl);
+        }
+
+        private static boolean isBlank(String value) {
+            return value == null || value.isBlank();
         }
     }
 
     public static class Execution extends SynchronousStepExecution<String> {
 
         private static final long serialVersionUID = 1L;
-        @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Only used when starting.")
         private transient final TriggerStep step;
 
         Execution(TriggerStep step, StepContext context) {
@@ -339,11 +341,11 @@ public class TriggerStep extends Step implements Serializable {
                 throw new MissingContextVariableException(Run.class);
             }
             String jenkinsUrl = step.jenkinsUrl;
-            if (StringUtils.isBlank(jenkinsUrl)) {
+            if (isBlank(jenkinsUrl)) {
                 // default to own
                 jenkinsUrl = JenkinsLocationConfiguration.get().getUrl();
             }
-            if (StringUtils.isBlank(jenkinsUrl)) {
+            if (isBlank(jenkinsUrl)) {
                 throw new IOException("Could not determine Jenkins URL");
             }
             jenkinsUrl = TriggerCredentialsImpl.normalizeUrl(jenkinsUrl);
@@ -354,15 +356,15 @@ public class TriggerStep extends Step implements Serializable {
                 throw new CredentialNotFoundException(
                         "Could not find credentials entry with ID '" + step.credentialsId + "'");
             }
-            if (!StringUtils.equals(jenkinsUrl, credentials.getJenkinsUrl())) {
+            if (!Objects.equals(jenkinsUrl, credentials.getJenkinsUrl())) {
                 throw new CredentialNotFoundException(
                         "Credentials with ID '" + step.credentialsId + "' are for " + credentials.getJenkinsUrl()
                                 + " not " + jenkinsUrl);
             }
             Secret secret = credentials.getPassword();
-            String jobUrl = StringUtils.removeEnd(jenkinsUrl, "/")
+            String jobUrl = removeTrailingSlash(jenkinsUrl)
                     + "/job/"
-                    + StringUtils.removeStart(StringUtils.removeEnd(step.job, "/"), "/")
+                    + removeLeadingSlash(removeTrailingSlash(step.job))
                     .replace("/", "/job/");
             TaskListener listener = getContext().get(TaskListener.class);
             assert listener != null;
@@ -424,7 +426,7 @@ public class TriggerStep extends Step implements Serializable {
                 }
                 String location = connection.getHeaderField("Location");
                 if (location.startsWith("/")) {
-                    location = StringUtils.removeEnd(jenkinsUrl, "/") + location;
+                    location = removeTrailingSlash(jenkinsUrl) + location;
                 }
                 listener.getLogger().printf("[%tc] Job queued as %s%n",
                         new Date(), HyperlinkNote.encodeTo(location, location)
@@ -433,6 +435,18 @@ public class TriggerStep extends Step implements Serializable {
             } finally {
                 connection.disconnect();
             }
+        }
+
+        private static boolean isBlank(String value) {
+            return value == null || value.isBlank();
+        }
+
+        private static String removeLeadingSlash(String value) {
+            return value.startsWith("/") ? value.substring(1) : value;
+        }
+
+        private static String removeTrailingSlash(String value) {
+            return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.buildtokentrigger;
 
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.IdCredentials;
@@ -309,10 +310,15 @@ public class TriggerStep extends Step implements Serializable {
                     URIRequirementBuilder.fromUri(jenkinsUrl).build(),
                     CredentialsMatchers.allOf(
                             CredentialsMatchers.instanceOf(TriggerCredentials.class),
-                            CredentialsMatchers
-                                    .withProperty("jenkinsUrl", TriggerCredentialsImpl.normalizeUrl(jenkinsUrl))
+                            matchingJenkinsUrl(jenkinsUrl)
                     )
             );
+        }
+
+        static CredentialsMatcher matchingJenkinsUrl(String jenkinsUrl) {
+            String normalizedUrl = TriggerCredentialsImpl.normalizeUrl(jenkinsUrl);
+            return credentials -> credentials instanceof TriggerCredentials
+                    && StringUtils.equals(((TriggerCredentials) credentials).getJenkinsUrl(), normalizedUrl);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
@@ -262,8 +262,7 @@ public class TriggerStep extends Step implements Serializable {
                 return FormValidation.ok();
             }
             if (StringUtils.isBlank(value)) {
-                JenkinsLocationConfiguration cfg = JenkinsLocationConfiguration.get();
-                String url = cfg == null ? null : cfg.getUrl();
+                String url = JenkinsLocationConfiguration.get().getUrl();
                 if (StringUtils.isBlank(url)) {
                     return FormValidation
                             .error("No Jenkins URL specified and this Jenkins has not been configured with a root URL"
@@ -342,8 +341,7 @@ public class TriggerStep extends Step implements Serializable {
             String jenkinsUrl = step.jenkinsUrl;
             if (StringUtils.isBlank(jenkinsUrl)) {
                 // default to own
-                JenkinsLocationConfiguration cfg = JenkinsLocationConfiguration.get();
-                jenkinsUrl = cfg == null ? jenkinsUrl : cfg.getUrl();
+                jenkinsUrl = JenkinsLocationConfiguration.get().getUrl();
             }
             if (StringUtils.isBlank(jenkinsUrl)) {
                 throw new IOException("Could not determine Jenkins URL");

--- a/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
@@ -27,6 +27,8 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.Extension;
@@ -60,13 +62,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -77,7 +77,8 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.verb.POST;
 
 /**
  * Pipeline step to trigger a build job on a remote Jenkins using a {@link BuildAuthorizationToken}.
@@ -183,14 +184,14 @@ public class TriggerStep extends Step implements Serializable {
             return "buildTokenTrigger";
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.TriggerStep_DisplayName();
         }
 
         @Override
-        public TriggerStep newInstance(@Nullable StaplerRequest req, @Nonnull JSONObject json)
+        public TriggerStep newInstance(@CheckForNull StaplerRequest2 req, @NonNull JSONObject json)
                 throws FormException {
             Map<String, String> parameters = new HashMap<>();
             Object parametersList = json.get("parametersList");
@@ -252,6 +253,7 @@ public class TriggerStep extends Step implements Serializable {
             return FormValidation.ok();
         }
 
+        @POST
         public FormValidation doCheckJenkinsUrl(@AncestorInPath Item owner,
                                                 @QueryParameter String value)
                 throws IOException {
@@ -270,7 +272,7 @@ public class TriggerStep extends Step implements Serializable {
                         "Will assume <code>" + Util.xmlEscape(url) + "</code> as the Jenkins URL");
             }
             URL url = new URL(TriggerCredentialsImpl.normalizeUrl(value));
-            ProxyConfiguration proxy = Jenkins.getInstance().proxy;
+            ProxyConfiguration proxy = Jenkins.get().proxy;
             HttpURLConnection connection;
             if (proxy == null) {
                 connection = (HttpURLConnection) url.openConnection();
@@ -291,6 +293,7 @@ public class TriggerStep extends Step implements Serializable {
 
         }
 
+        @POST
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item owner,
                                                      @QueryParameter("jenkinsUrl") String jenkinsUrl,
                                                      @QueryParameter String value) {
@@ -301,8 +304,8 @@ public class TriggerStep extends Step implements Serializable {
                     IdCredentials.class,
                     owner,
                     owner instanceof Queue.Task
-                            ? Tasks.getAuthenticationOf((Queue.Task) owner)
-                            : ACL.SYSTEM,
+                            ? Tasks.getAuthenticationOf2((Queue.Task) owner)
+                            : ACL.SYSTEM2,
                     URIRequirementBuilder.fromUri(jenkinsUrl).build(),
                     CredentialsMatchers.allOf(
                             CredentialsMatchers.instanceOf(TriggerCredentials.class),
@@ -378,7 +381,7 @@ public class TriggerStep extends Step implements Serializable {
                 data.append(URLEncoder.encode(entry.getValue(), "UTF-8"));
             }
             URL trigger = new URL(triggerUrl);
-            ProxyConfiguration proxy = Jenkins.getInstance().proxy;
+            ProxyConfiguration proxy = Jenkins.get().proxy;
             HttpURLConnection connection;
             if (proxy == null) {
                 connection = (HttpURLConnection) trigger.openConnection();

--- a/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
+++ b/src/main/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStep.java
@@ -301,7 +301,7 @@ public class TriggerStep extends Step implements Serializable {
             if (owner == null || !owner.hasPermission(Item.CONFIGURE)) {
                 return new ListBoxModel().add(value);
             }
-            return CredentialsProvider.listCredentials(
+            return CredentialsProvider.listCredentialsInItem(
                     IdCredentials.class,
                     owner,
                     owner instanceof Queue.Task

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <Match>
+    <!-- Synchronous step executions are not persisted while run() is active. -->
+    <And>
+      <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED" />
+      <Class name="org.jenkinsci.plugins.buildtokentrigger.TriggerStep$Execution" />
+      <Field name="step" />
+    </And>
+  </Match>
+</FindBugsFilter>

--- a/src/test/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentialsImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildtokentrigger/TriggerCredentialsImplTest.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Build Token Trigger Plugin contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.buildtokentrigger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TriggerCredentialsImplTest {
+
+    @Test
+    void normalizesHostDefaultPortAndTrailingSlash() {
+        assertEquals(
+                "https://jenkins.example.com/path",
+                TriggerCredentialsImpl.normalizeUrl("https://JENKINS.EXAMPLE.COM:443/path/"));
+    }
+
+    @Test
+    void keepsNonDefaultPort() {
+        assertEquals(
+                "http://jenkins.example.com:8080/jenkins",
+                TriggerCredentialsImpl.normalizeUrl("http://JENKINS.EXAMPLE.COM:8080/jenkins/"));
+    }
+
+    @Test
+    void handlesMissingValue() {
+        assertEquals("", TriggerCredentialsImpl.normalizeUrl(null));
+    }
+
+    @Test
+    void preservesInvalidInputAfterBestEffortCleanup() {
+        assertEquals("not a URL", TriggerCredentialsImpl.normalizeUrl("not a URL/"));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStepIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStepIntegrationTest.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Build Token Trigger Plugin contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.buildtokentrigger;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import hudson.model.AbstractProject;
+import hudson.model.BuildAuthorizationToken;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import java.lang.reflect.Field;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class TriggerStepIntegrationTest {
+
+    @Test
+    void triggersBuildOnSameJenkins(JenkinsRule j) throws Exception {
+        FreeStyleProject target = j.createFreeStyleProject("target");
+        setAuthToken(target, "secret");
+
+        String jenkinsUrl = j.getURL().toString();
+        SystemCredentialsProvider credentialsProvider = SystemCredentialsProvider.getInstance();
+        credentialsProvider.getCredentials().add(new TriggerCredentialsImpl(
+                CredentialsScope.GLOBAL, "self-token", null, jenkinsUrl, "secret"));
+        credentialsProvider.save();
+
+        WorkflowJob caller = j.jenkins.createProject(WorkflowJob.class, "caller");
+        caller.setDefinition(new CpsFlowDefinition(
+                "buildTokenTrigger credentialsId: 'self-token', jenkinsUrl: '" + jenkinsUrl
+                        + "', job: 'target', parameters: [:], delay: 0",
+                true));
+
+        WorkflowRun callerBuild = j.buildAndAssertSuccess(caller);
+        j.waitUntilNoActivity();
+
+        FreeStyleBuild targetBuild = target.getLastBuild();
+        assertNotNull(targetBuild);
+        j.assertBuildStatusSuccess(targetBuild);
+        j.assertLogContains("Job queued as", callerBuild);
+    }
+
+    private static void setAuthToken(FreeStyleProject project, String token) throws Exception {
+        Field authToken = AbstractProject.class.getDeclaredField("authToken");
+        authToken.setAccessible(true);
+        authToken.set(project, new BuildAuthorizationToken(token));
+        project.save();
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStepIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStepIntegrationTest.java
@@ -47,16 +47,14 @@ class TriggerStepIntegrationTest {
         FreeStyleProject target = j.createFreeStyleProject("target");
         setAuthToken(target, "secret");
 
-        String jenkinsUrl = j.getURL().toString();
         SystemCredentialsProvider credentialsProvider = SystemCredentialsProvider.getInstance();
         credentialsProvider.getCredentials().add(new TriggerCredentialsImpl(
-                CredentialsScope.GLOBAL, "self-token", null, jenkinsUrl, "secret"));
+                CredentialsScope.GLOBAL, "self-token", null, j.getURL().toString(), "secret"));
         credentialsProvider.save();
 
         WorkflowJob caller = j.jenkins.createProject(WorkflowJob.class, "caller");
         caller.setDefinition(new CpsFlowDefinition(
-                "buildTokenTrigger credentialsId: 'self-token', jenkinsUrl: '" + jenkinsUrl
-                        + "', job: 'target', parameters: [:], delay: 0",
+                "buildTokenTrigger credentialsId: 'self-token', jenkinsUrl: JENKINS_URL, job: 'target'",
                 true));
 
         WorkflowRun callerBuild = j.buildAndAssertSuccess(caller);

--- a/src/test/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/buildtokentrigger/TriggerStepTest.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Build Token Trigger Plugin contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.buildtokentrigger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import org.junit.jupiter.api.Test;
+
+class TriggerStepTest {
+
+    @Test
+    void matchesCredentialsForNormalizedJenkinsUrl() {
+        CredentialsMatcher matcher = TriggerStep.DescriptorImpl.matchingJenkinsUrl(
+                "https://JENKINS.EXAMPLE.COM:443/");
+
+        assertTrue(matcher.matches(credentials("matching", "https://jenkins.example.com")));
+        assertFalse(matcher.matches(credentials("other", "https://other.example.com")));
+    }
+
+    private static TriggerCredentialsImpl credentials(String id, String jenkinsUrl) {
+        return new TriggerCredentialsImpl(CredentialsScope.GLOBAL, id, null, jenkinsUrl, "secret");
+    }
+}


### PR DESCRIPTION
## Summary

- update the Jenkins plugin parent from 3.6 to 6.2208.vb_6798604237e
- move the Jenkins baseline from 2.89.1 to 2.541.3
- import the Jenkins plugin BOM for maintained dependency versions
- replace deprecated Jenkins, Stapler, authentication, and annotation APIs
- replace Commons Lang string helpers with JDK APIs
- require POST for endpoints that inspect credentials or make a remote request
- add regression tests for Jenkins URL normalization and credential filtering
- add a JenkinsRule integration test that triggers a build on the same Jenkins
- add Jenkins Incrementals metadata and the official continuous-delivery workflow

## Motivation

This plugin is marked for adoption and has not been released since 2018. This
change restores a current Jenkins build foundation without intentionally
changing the Pipeline step's user-facing behavior. It is intended to be the
first maintenance change associated with adopting the plugin.

## Verification

- `git diff --check` passes
- `pom.xml` parses as well-formed XML
- `mvn -B -ntp clean verify` passes locally with 13 tests, SpotBugs, HPI
  packaging, and Jenkins plugin compatibility checks
- Ubuntu/JDK 25 mvn -B -ntp clean verify passes with all 13 tests and SpotBugs:
  https://github.com/zerlinpi/build-token-trigger-plugin/actions/runs/29423010385
- the focused JenkinsRule integration test passes and verifies the real
  Pipeline step, credentials lookup, build-token-root endpoint, and target build
- ci.jenkins.io Linux/JDK 25, Linux/JDK 21, and Windows/JDK 17 matrix passes:
  https://ci.jenkins.io/job/Plugins/job/build-token-trigger-plugin/job/PR-6/10/

## Review follow-ups

- Jenkins CD permission (merged):
  https://github.com/jenkins-infra/repository-permissions-updater/pull/5155
- Add `build-token-root` to the Jenkins plugin BOM:
  https://github.com/jenkinsci/bom/pull/7076

## Release readiness

- Jenkins CD permission is merged in jenkins-infra/repository-permissions-updater#5155
- repository secret names `MAVEN_TOKEN` and `MAVEN_USERNAME` are present
- the `enhancement` label is applied so the default JEP-229 workflow treats this as a release-triggering change
- local Maven evaluation with `-Dset.changelist -Dignore.dirt` produces the standard CD version form (`18.v4765ec363b_a_2` locally; the final suffix follows the merged commit)

## Compatibility

The minimum Jenkins version increases to 2.541.3, consistent with the current
Jenkins plugin baseline guidance. Existing `TriggerCredentials` and
`TriggerCredentialsImpl` types are retained so persisted credentials continue
to load. No persisted model fields or Pipeline step parameters are changed.